### PR TITLE
Add webcam virtual channel skeleton

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -57,6 +57,7 @@ libguac_client_rdp_la_SOURCES =                  \
     channels/rdpdr/rdpdr.c                       \
     channels/rdpei.c                             \
     channels/rdpgfx.c                            \
+    channels/webcam.c                           \
     channels/rdpsnd/rdpsnd-messages.c            \
     channels/rdpsnd/rdpsnd.c                     \
     client.c                                     \
@@ -103,6 +104,7 @@ noinst_HEADERS =                                 \
     channels/rdpdr/rdpdr.h                       \
     channels/rdpei.h                             \
     channels/rdpgfx.h                            \
+    channels/webcam.h                            \
     channels/rdpsnd/rdpsnd-messages.h            \
     channels/rdpsnd/rdpsnd.h                     \
     client.h                                     \

--- a/src/protocols/rdp/channels/webcam.c
+++ b/src/protocols/rdp/channels/webcam.c
@@ -1,0 +1,84 @@
+#include "channels/webcam.h"
+#include "plugins/channels.h"
+#include "rdp.h"
+
+#include <guacamole/client.h>
+#include <guacamole/mem.h>
+#include <winpr/stream.h>
+
+#include <string.h>
+
+/* Allocate a new webcam structure. */
+guac_rdp_webcam* guac_rdp_webcam_alloc(guac_client* client) {
+    guac_rdp_webcam* webcam = guac_mem_alloc(sizeof(guac_rdp_webcam));
+    webcam->client = client;
+    webcam->svc = NULL;
+    return webcam;
+}
+
+/* Free a webcam structure. */
+void guac_rdp_webcam_free(guac_rdp_webcam* webcam) {
+    guac_mem_free(webcam);
+}
+
+/* Handler called when the SVC connects. */
+static void guac_rdp_webcam_connected(guac_rdp_common_svc* svc) {
+    guac_rdp_client* rdp_client = (guac_rdp_client*) svc->client->data;
+    rdp_client->webcam->svc = svc;
+    svc->data = rdp_client->webcam;
+    guac_client_log(svc->client, GUAC_LOG_DEBUG,
+            "Webcam channel connected.");
+}
+
+/* Handler called when data is received. This implementation simply ignores
+ * incoming data from the server. */
+static void guac_rdp_webcam_receive(guac_rdp_common_svc* svc,
+        wStream* input_stream) {
+    guac_client_log(svc->client, GUAC_LOG_DEBUG,
+            "Ignoring %" PRIuz " bytes received on webcam channel",
+            Stream_GetRemainingLength(input_stream));
+}
+
+/* Handler called when the channel is closed. */
+static void guac_rdp_webcam_terminate(guac_rdp_common_svc* svc) {
+    guac_rdp_client* rdp_client = (guac_rdp_client*) svc->client->data;
+    if (rdp_client->webcam != NULL)
+        rdp_client->webcam->svc = NULL;
+    guac_client_log(svc->client, GUAC_LOG_DEBUG,
+            "Webcam channel disconnected.");
+}
+
+void guac_rdp_webcam_load_plugin(rdpContext* context) {
+    guac_client* client = ((rdp_freerdp_context*) context)->client;
+    /* Attempt to load a static channel named \"GUACCAM\" */
+    if (guac_rdp_common_svc_load_plugin(context, "GUACCAM", 0,
+                guac_rdp_webcam_connected, guac_rdp_webcam_receive,
+                guac_rdp_webcam_terminate)) {
+        guac_client_log(client, GUAC_LOG_WARNING,
+                "Support for the webcam channel could not be loaded.");
+    }
+}
+
+int guac_rdp_webcam_send_frame(guac_rdp_webcam* webcam,
+        const void* data, int length, int width, int height) {
+
+    if (webcam == NULL || webcam->svc == NULL)
+        return 1;
+
+    int packet_size = sizeof(guac_rdp_webcam_frame_header) + length;
+    wStream* output = Stream_New(NULL, packet_size);
+
+    guac_rdp_webcam_frame_header header = {
+        .width = width,
+        .height = height,
+        .format = GUAC_RDP_WEBCAM_FORMAT_RGB24,
+        .length = length
+    };
+
+    Stream_Write(output, &header, sizeof(header));
+    Stream_Write(output, data, length);
+    guac_rdp_common_svc_write(webcam->svc, output);
+
+    return 0;
+}
+

--- a/src/protocols/rdp/channels/webcam.h
+++ b/src/protocols/rdp/channels/webcam.h
@@ -1,0 +1,40 @@
+#ifndef GUAC_RDP_CHANNELS_WEBCAM_H
+#define GUAC_RDP_CHANNELS_WEBCAM_H
+
+#include "settings.h"
+#include "channels/common-svc.h"
+
+#include <freerdp/freerdp.h>
+#include <guacamole/client.h>
+
+/** Representation of a webcam channel. */
+typedef struct guac_rdp_webcam {
+    guac_client* client;          /**< Associated Guacamole client. */
+    guac_rdp_common_svc* svc;     /**< The underlying static virtual channel. */
+} guac_rdp_webcam;
+
+/** Basic frame header for webcam frames sent through the channel. */
+typedef struct guac_rdp_webcam_frame_header {
+    uint32_t width;   /**< Width of the frame in pixels. */
+    uint32_t height;  /**< Height of the frame in pixels. */
+    uint32_t format;  /**< Pixel format identifier. */
+    uint32_t length;  /**< Length of the frame data in bytes. */
+} guac_rdp_webcam_frame_header;
+
+/** Raw RGB24 pixel format identifier. */
+#define GUAC_RDP_WEBCAM_FORMAT_RGB24 0
+
+/* Allocate a new webcam structure. */
+guac_rdp_webcam* guac_rdp_webcam_alloc(guac_client* client);
+
+/* Free a webcam structure. */
+void guac_rdp_webcam_free(guac_rdp_webcam* webcam);
+
+/* Load the webcam plugin if enabled. */
+void guac_rdp_webcam_load_plugin(rdpContext* context);
+
+/* Send a frame over the webcam channel. */
+int guac_rdp_webcam_send_frame(guac_rdp_webcam* webcam,
+        const void* data, int length, int width, int height);
+
+#endif /* GUAC_RDP_CHANNELS_WEBCAM_H */

--- a/src/protocols/rdp/client.c
+++ b/src/protocols/rdp/client.c
@@ -23,6 +23,7 @@
 #include "channels/disp.h"
 #include "channels/pipe-svc.h"
 #include "channels/rail.h"
+#include "channels/webcam.h"
 #include "config.h"
 #include "fs.h"
 #include "log.h"
@@ -218,6 +219,9 @@ int guac_client_init(guac_client* client, int argc, char** argv) {
     /* Init multi-touch support module (RDPEI) */
     rdp_client->rdpei = guac_rdp_rdpei_alloc(client);
 
+    /* Init webcam channel */
+    rdp_client->webcam = guac_rdp_webcam_alloc(client);
+
     /* Redirect FreeRDP log messages to guac_client_log() */
     guac_rdp_redirect_wlog(client);
 
@@ -275,6 +279,9 @@ int guac_rdp_client_free_handler(guac_client* client) {
 
     /* Free multi-touch support module (RDPEI) */
     guac_rdp_rdpei_free(rdp_client->rdpei);
+
+    /* Free webcam channel */
+    guac_rdp_webcam_free(rdp_client->webcam);
 
     /* Clean up filesystem, if allocated */
     if (rdp_client->filesystem != NULL)

--- a/src/protocols/rdp/rdp.c
+++ b/src/protocols/rdp/rdp.c
@@ -119,6 +119,10 @@ static BOOL rdp_freerdp_load_channels(freerdp* instance) {
         guac_rwlock_release_lock(&(rdp_client->lock));
     }
 
+    /* Load webcam channel if enabled */
+    if (settings->enable_webcam)
+        guac_rdp_webcam_load_plugin(context);
+
     /* Load "cliprdr" service if not disabled */
     if (!(settings->disable_copy && settings->disable_paste))
         guac_rdp_clipboard_load_plugin(rdp_client->clipboard, context);

--- a/src/protocols/rdp/rdp.h
+++ b/src/protocols/rdp/rdp.h
@@ -24,6 +24,7 @@
 #include "channels/cliprdr.h"
 #include "channels/disp.h"
 #include "channels/rdpei.h"
+#include "channels/webcam.h"
 #include "common/clipboard.h"
 #include "common/list.h"
 #include "config.h"
@@ -217,6 +218,11 @@ typedef struct guac_rdp_client {
      * Multi-touch support module (RDPEI).
      */
     guac_rdp_rdpei* rdpei;
+
+    /**
+     * Webcam support channel.
+     */
+    guac_rdp_webcam* webcam;
 
     /**
      * List of all available static virtual channels.

--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -130,6 +130,7 @@ const char* GUAC_RDP_CLIENT_ARGS[] = {
     "resize-method",
     "enable-audio-input",
     "enable-touch",
+    "enable-webcam",
     "read-only",
 
     "gateway-hostname",
@@ -610,6 +611,12 @@ enum RDP_ARGS_IDX {
      * "false" or blank otherwise.
      */
     IDX_ENABLE_TOUCH,
+
+    /**
+     * "true" if webcam redirection should be enabled for the RDP connection,
+     * "false" or blank otherwise.
+     */
+    IDX_ENABLE_WEBCAM,
 
     /**
      * "true" if this connection should be read-only (user input should be
@@ -1259,6 +1266,11 @@ guac_rdp_settings* guac_rdp_parse_args(guac_user* user,
     settings->enable_audio_input =
         guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
                 IDX_ENABLE_AUDIO_INPUT, 0);
+
+    /* Webcam redirection enable/disable */
+    settings->enable_webcam =
+        guac_user_parse_args_boolean(user, GUAC_RDP_CLIENT_ARGS, argv,
+                IDX_ENABLE_WEBCAM, 0);
 
     /* Set gateway hostname */
     settings->gateway_hostname =

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -617,6 +617,11 @@ typedef struct guac_rdp_settings {
     int enable_touch;
 
     /**
+     * Whether webcam redirection is enabled.
+     */
+    int enable_webcam;
+
+    /**
      * The hostname of the remote desktop gateway that should be used as an
      * intermediary for the remote desktop connection. If no gateway should
      * be used, this will be NULL.


### PR DESCRIPTION
## Summary
- define webcam virtual channel structures and packet format
- register new channel in build scripts
- allocate/free webcam handler with client lifecycle
- load webcam channel when enabled via settings
- add `enable-webcam` setting for RDP

## Testing
- `autoreconf -fi` *(fails: command not found)*
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_b_685d3fedadcc8326ac30d20e3994f999