### PR TITLE
Fix duplicate webcam settings definition

### DIFF
--- a/src/protocols/rdp/settings.c
+++ b/src/protocols/rdp/settings.c
@@ -620,12 +620,6 @@ enum RDP_ARGS_IDX {
     IDX_ENABLE_TOUCH,
 
     /**
-     * "true" if webcam redirection should be enabled for the RDP connection,
-     * "false" or blank otherwise.
-     */
-    IDX_ENABLE_WEBCAM,
-
-    /**
      * "true" if this connection should be read-only (user input should be
      * dropped), "false" or blank otherwise.
      */

--- a/src/protocols/rdp/settings.h
+++ b/src/protocols/rdp/settings.h
@@ -622,11 +622,6 @@ typedef struct guac_rdp_settings {
     int enable_touch;
 
     /**
-     * Whether webcam redirection is enabled.
-     */
-    int enable_webcam;
-
-    /**
      * The hostname of the remote desktop gateway that should be used as an
      * intermediary for the remote desktop connection. If no gateway should
      * be used, this will be NULL.


### PR DESCRIPTION
## Summary
- remove duplicate `enable_webcam` member from `guac_rdp_settings`
- drop redundant `IDX_ENABLE_WEBCAM` enum entry

## Testing
- `autoreconf -fi` *(fails: command not found)*
- `./configure` *(fails: no such file)*
- `make` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_b_685e3190e10c832683b65580c94a8510