### PR TITLE
Update RDP webcam CFLAGS

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -217,6 +217,7 @@ libguacvc_client_la_SOURCES =           \
 libguacvc_client_la_CFLAGS = \
     -Werror -Wall -Iinclude       \
     @COMMON_INCLUDE@              \
+    @COMMON_SSH_INCLUDE@          \
     @LIBGUAC_INCLUDE@             \
     @RDP_CFLAGS@
 


### PR DESCRIPTION
## Summary
- include ssh headers for the webcam virtual channel

## Testing
- `autoreconf -fi` *(fails: command not found)*
- `./configure` *(fails: No such file)*
- `make` *(fails: No makefile found)*


------
https://chatgpt.com/codex/tasks/task_b_685e35898f908326a98d8c6860a79304