### PR TITLE
Fix webcam plugin header guard

### DIFF
--- a/src/protocols/rdp/channels/webcam/webcam.h
+++ b/src/protocols/rdp/channels/webcam/webcam.h
@@ -1,5 +1,5 @@
-#ifndef GUAC_RDP_CHANNELS_WEBCAM_H
-#define GUAC_RDP_CHANNELS_WEBCAM_H
+#ifndef GUAC_RDP_CHANNELS_WEBCAM_PLUGIN_H
+#define GUAC_RDP_CHANNELS_WEBCAM_PLUGIN_H
 
 #include <freerdp/freerdp.h>
 #include <guacamole/user.h>
@@ -18,4 +18,4 @@ int guac_rdp_webcam_end_handler(guac_user* user, guac_stream* stream);
 /* Adds Guacamole's webcam plugin to the dynamic channel list */
 void guac_rdp_webcam_load_plugin(rdpContext* context);
 
-#endif
+#endif /* GUAC_RDP_CHANNELS_WEBCAM_PLUGIN_H */


### PR DESCRIPTION
## Summary
- rename the header guard used for the webcam dynamic channel plugin

The previous guard clashed with `channels/webcam.h`, leading to the
`guac_rdp_webcam` type being undefined when compiling `webcam.c` in the
plugin directory.

## Testing
- `autoreconf -fi` *(fails: command not found)*
- `./configure` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685e36c9154c8326ab70a2dee67faf65