### PR TITLE
Fix missing include and add forward declaration

### DIFF
--- a/src/protocols/rdp/user.c
+++ b/src/protocols/rdp/user.c
@@ -43,6 +43,10 @@
 
 #include <pthread.h>
 #include <stddef.h>
+#include <string.h>
+
+static int guac_rdp_user_pipe_handler(guac_user* user, guac_stream* stream,
+        char* mimetype, char* name);
 
 int guac_rdp_user_join_handler(guac_user* user, int argc, char** argv) {
 


### PR DESCRIPTION
## Summary
- include `<string.h>` in `src/protocols/rdp/user.c`
- add a forward declaration for `guac_rdp_user_pipe_handler`

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_b_685e39b52e80832690311c587c104d9d